### PR TITLE
Add missing ES6 rules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -145,15 +145,21 @@ rules:
   wrap-regex: 2
 
   # ECMAScript 6
+  arrow-parens: [2, as-needed]
   arrow-spacing: 2
   constructor-super: 2
   generator-star-spacing: 2
+  no-arrow-condition: 2
   no-class-assign: 2
   no-const-assign: 2
   no-dupe-class-members: 2
   no-this-before-super: 2
   no-var: 2
+  object-shorthand: 2
+  prefer-arrow-callback: 2
   prefer-const: 2
+  prefer-spread: 2
+  prefer-template: 2
   require-yield: 2
 
   # Legacy

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/seegno/eslint-config-seegno#readme",
   "dependencies": {
-    "eslint": "^1.6.0"
+    "eslint": "^1.8.0"
   },
   "devDependencies": {
     "babel": "^5.8.23",
@@ -40,7 +40,7 @@
   },
   "peerDependencies": {
     "babel-eslint": ">= 4.1",
-    "eslint": ">= 1.6"
+    "eslint": ">= 1.8"
   },
   "engines": {
     "node": ">= 4.0.0"


### PR DESCRIPTION
Note that _eslint_ had to be bumped to 1.8.0 due to the `no-arrow-condition` rule.

Deprecates #4.

R=@ruiquelhas