### PR TITLE
Fix async arrow functions

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,6 +7,9 @@ extends: 'eslint:recommended'
 
 parser: 'babel-eslint'
 
+plugins:
+  - babel
+
 root: true
 
 rules:
@@ -145,7 +148,6 @@ rules:
   wrap-regex: 2
 
   # ECMAScript 6
-  arrow-parens: [2, as-needed]
   arrow-spacing: 2
   constructor-super: 2
   generator-star-spacing: 2
@@ -161,6 +163,9 @@ rules:
   prefer-spread: 2
   prefer-template: 2
   require-yield: 2
+
+  # Babel plugin
+  babel/arrow-parens: [2, as-needed]
 
   # Legacy
   max-depth: 2

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Seegno-flavored ESLint config.
 ## Installation
 
 ```sh
-$ npm install eslint babel-eslint eslint-config-seegno --save-dev
+$ npm install eslint babel-eslint eslint-plugin-babel eslint-config-seegno --save-dev
 ```
 
 ## Usage

--- a/package.json
+++ b/package.json
@@ -35,12 +35,14 @@
   "devDependencies": {
     "babel": "^5.8.23",
     "babel-eslint": "^4.1.3",
+    "eslint-plugin-babel": "^2.1.1",
     "mocha": "^2.3.3",
     "should": "^7.1.0"
   },
   "peerDependencies": {
     "babel-eslint": ">= 4.1",
-    "eslint": ">= 1.8"
+    "eslint": ">= 1.8",
+    "eslint-plugin-babel": ">= 2.1"
   },
   "engines": {
     "node": ">= 4.0.0"


### PR DESCRIPTION
This PR adds a new dependency — the babel eslint plugin — which allows us to correctly use async arrow functions:

```js
it('should work', async () => {
  await something();
});
```

This plugin is needed because Babel [has stated](https://github.com/eslint/eslint/issues/3354#issuecomment-129935329) that they can't handle this natively and moved this responsibility to [eslint-plugin-babel](https://github.com/babel/eslint-plugin-babel/issues/8).

Note that this only works because `arrow-parens` was already disabled (incorrectly) here: https://github.com/seegno/eslint-config-seegno/compare/bugfix/fix-async-arrow-functions?expand=1#diff-1dc6ee56b778cd91e0327b52aaeaa1b9R18