### PR TITLE
Fix arrow function in variable declarations

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -129,7 +129,7 @@ rules:
   # Stylistic issues
   computed-property-spacing: 2
   consistent-this: 2
-  func-style: 2
+  func-style: [2, declaration, { allowArrowFunctions: true }]
   id-length: [2, { exceptions: [_, e, i] }]
   max-nested-callbacks: [2, 4]
   new-parens: 2


### PR DESCRIPTION
This allows us to do:

```js
const request = () => ({ body: {}, statusCode: 200 });
```

See [relevant rule](http://eslint.org/docs/rules/func-style).