### PR TITLE
Update `arrow-parens` rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -165,7 +165,7 @@ rules:
   require-yield: 2
 
   # Babel plugin
-  babel/arrow-parens: [2, as-needed]
+  babel/arrow-parens: [2, always]
   babel/generator-star-spacing: [2, after]
 
   # Legacy


### PR DESCRIPTION
- Update `arrow-parens` rule to make the use of parenthesis required on every arrow
  function.
- Fixes #6 