### PR TITLE
Remove `no-ternary` rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -139,7 +139,6 @@ rules:
   no-lonely-if: 2
   no-nested-ternary: 2
   no-new-object: 2
-  no-ternary: 2
   no-trailing-spaces: 2
   no-unneeded-ternary: 2
   operator-assignment: 2


### PR DESCRIPTION
Closes #12.