### PR TITLE
Remove `babel/arrow-parens` requirement

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -164,7 +164,7 @@ rules:
   require-yield: 2
 
   # Babel plugin
-  babel/arrow-parens: [2, always]
+  babel/arrow-parens: 0
   babel/generator-star-spacing: [2, after]
 
   # Legacy


### PR DESCRIPTION
After some discussion, no consensus was reached regarding this rule, so for now, I suggest we just remove the requirement.  