### PR TITLE
Update `semi` and `semi-spacing` rules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -56,8 +56,8 @@ rules:
   prefer-template: 0
   quote-props: 0
   quotes: 0
-  semi-spacing: 0
-  semi: 0
+  semi-spacing: 2
+  semi: 2
   space-after-keywords: 0
   space-before-blocks: 0
   space-before-function-paren: 0


### PR DESCRIPTION
This PR updates rules to avoid the following:

```js
const foo = 'bar' ;
const biz = 'baz'
```