### PR TITLE
Remove duplicated rules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -52,8 +52,6 @@ rules:
   one-var: 0
   operator-linebreak: 0
   padded-blocks: 0
-  prefer-spread: 0
-  prefer-template: 0
   quote-props: 0
   quotes: 0
   semi-spacing: 0


### PR DESCRIPTION
This PR removes duplicated `prefer-spread` and `prefer-template` rules, added with #5. This is related with [js-yaml](https://github.com/nodeca/js-yaml/commit/9ea29ec6aa5e48d3dff3eacf7582818643a0ab0c), which handles duplicated key mapping with exceptions, after release **3.5.0**.

Fixes #21.