### PR TITLE
Require arrow parentheses as needed

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,7 @@ module.exports = {
     'array-bracket-spacing': 0,
     'arrow-parens': 0,
     'arrow-spacing': 2,
-    'babel/arrow-parens': [2, 'always'],
+    'babel/arrow-parens': [2, 'as-needed'],
     'babel/generator-star-spacing': [2, 'before'],
     'block-scoped-var': 2,
     'block-spacing': 0,


### PR DESCRIPTION
Follow [2016's resolution]( https://github.com/seegno/eslint-config-seegno/issues/6#issuecomment-169735727) of removing gratuitous arrow parethenses, I'd like to re-evaluate the need for the "always" rule. 

![200](https://cloud.githubusercontent.com/assets/288709/12814600/275eebe4-cb38-11e5-8dd8-5e0af5bd9fda.gif)
