### PR TITLE
Add rule to sort imports

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -163,6 +163,11 @@ module.exports = {
     'space-infix-ops': 'off',
     'space-unary-ops': 'off',
     'spaced-comment': 'off',
+    'sort-imports': ['error', {
+      'ignoreCase': false,
+      'ignoreMemberSort': false,
+      'memberSyntaxSortOrder': ['none', 'all', 'single', 'multiple']
+    }],
     strict: 'off',
     'valid-jsdoc': 'error',
     'vars-on-top': 'error',


### PR DESCRIPTION
It's finally a reality!

Current sort order:

```js
// none
import 'my-module.js';
// all
import * as foo from 'src';
// single default
import _ from 'lodash';
// single named
import { activity } from '../enums';
// multiple named (case and member order matters)
import { A, B, C, a } from 'validator.js';
```

On a side note, the default sort order of eslint is `["none", "all", "multiple", "single"]` instead of `["none", "all", "single", "multiple"]`. If you have a strong opinion about the form, please let us know on this PR.

The example above would become:

```js
// none
import 'my-module.js';
// all
import * as foo from 'src';
// multiple named (case and member order matters)
import { A, B, C, a } from 'validator.js';
// single default
import _ from 'lodash';
// single named
import { activity } from '../enums';
```
