### PR TITLE
Add recommended configuration of sort-class-members plugin

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ module.exports = {
     mocha: true,
     node: true
   },
-  extends: 'eslint:recommended',
+  extends: ['eslint:recommended', 'plugin:sort-class-members/recommended'],
   parser: 'babel-eslint',
   plugins: ['babel', 'sort-class-members'],
   root: true,
@@ -158,18 +158,6 @@ module.exports = {
     'require-yield': 'error',
     semi: 'off',
     'semi-spacing': 'off',
-    'sort-class-members/sort-class-members': ['error', {
-      order: [
-        'constructor',
-        '[static-methods]',
-        '[static-properties]',
-        '[properties]',
-        '[methods]',
-        '[conventional-private-properties]',
-        '[conventional-private-methods]',
-        '[everything-else]'
-      ],
-    }],
     'sort-vars': 'error',
     'space-before-blocks': 'off',
     'space-before-function-paren': 'off',

--- a/test/index.js
+++ b/test/index.js
@@ -24,12 +24,13 @@ describe('eslint-config-seegno', () => {
     config.env.node.should.be.true();
   });
 
-  it('should extend `eslint:recommended`', () => {
-    config.extends.should.equal('eslint:recommended');
+  it('should extend `eslint:recommended` and `plugin:sort-class-members/recommended`', () => {
+    config.extends.should.be.an.Array().and.should.not.be.empty();
+    config.extends[0].should.equal('eslint:recommended');
+    config.extends[1].should.equal('plugin:sort-class-members/recommended');
   });
 
   it('should use `babel-eslint` as parser', () => {
-
     config.parser.should.equal('babel-eslint');
   });
 


### PR DESCRIPTION
This PR adds exported recommended configuration of _sort-class-members_ plugin and removes previous custom configuration.

Closes #42.