### PR TITLE
Add `brace-style` rule

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,9 @@ module.exports = {
     'babel/generator-star-spacing': ['error', 'before'],
     'block-scoped-var': 'error',
     'block-spacing': 'off',
-    'brace-style': 'off',
+    'brace-style': ['error', '1tbs', {
+      allowSingleLine: true
+    }],
     camelcase: 'off',
     'comma-dangle': 'error',
     'comma-spacing': 'error',

--- a/test/fixtures/correct.js
+++ b/test/fixtures/correct.js
@@ -6,6 +6,15 @@ function noop() {
 // `array-bracket-spacing`, `comma-spacing` and `no-multi-spaces`.
 noop(['bar', 'foo']);
 
+// `brace-style`.
+try {
+  noop();
+} catch (e) {
+  noop();
+}
+
+noop(function *() { return yield noop(); });
+
 // `comma-dangle`, `comma-style`.
 noop({ bar: 'foo', foo: 'bar' });
 
@@ -87,8 +96,13 @@ if (noConstantCondition) {
 
 // `no-dupe-class-members`.
 class NoDupeClassMembers {
-  bar() { return 'bar'; }
-  foo() { return 'foo'; }
+  bar() {
+    return 'bar';
+  }
+
+  foo() {
+    return 'foo';
+  }
 }
 
 noop(NoDupeClassMembers);

--- a/test/fixtures/incorrect.js
+++ b/test/fixtures/incorrect.js
@@ -6,6 +6,14 @@ function noop() {
 // `array-bracket-spacing`.
 noop([ 'bar', 'foo']);
 
+// `brace-style`.
+try {
+  noop();
+}
+catch (e) {
+  noop();
+}
+
 // `comma-dangle`.
 noop({ bar: 'foo', foo: 'bar', });
 
@@ -81,8 +89,13 @@ if (true) {
 
 // `no-dupe-class-members`.
 class NoDupeClassMembers {
-  foo() { return 'bar'; }
-  foo() { return 'foo'; }
+  foo() {
+    return 'bar';
+  }
+
+  foo() {
+    return 'foo';
+  }
 }
 
 noop(NoDupeClassMembers);

--- a/test/index.js
+++ b/test/index.js
@@ -35,6 +35,7 @@ describe('eslint-config-seegno', () => {
 
     linter.executeOnFiles([source]).results[0].messages.map(violation => violation.ruleId).should.containDeep([
       'array-bracket-spacing',
+      'brace-style',
       'comma-dangle',
       'comma-spacing',
       'comma-style',


### PR DESCRIPTION
The default setting of this rule enforces the following style:

```js
keyword {
  //
} keyword {
  //
}
```

This is the style we use, so we might as well add this rule, so that it gets documented.

More info: http://eslint.org/docs/rules/brace-style.