### PR TITLE
Add `one-var-declaration-per-line` rule

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -136,6 +136,7 @@ module.exports = {
     'object-curly-spacing': ['error', 'always'],
     'object-shorthand': 'error',
     'one-var': ['error', 'never'],
+    'one-var-declaration-per-line': ['error', 'always'],
     'operator-assignment': 'error',
     'operator-linebreak': ['error', 'none'],
     'padded-blocks': ['error', 'never'],

--- a/test/fixtures/correct.js
+++ b/test/fixtures/correct.js
@@ -152,7 +152,7 @@ const objectCurlySpacing2 = {};
 noop(objectCurlySpacing1);
 noop(objectCurlySpacing2);
 
-// `one-var`.
+// `one-var`, `one-var-declaration-per-line`.
 const oneVar1 = 'foo';
 const oneVar2 = 'bar';
 

--- a/test/fixtures/incorrect.js
+++ b/test/fixtures/incorrect.js
@@ -174,6 +174,12 @@ const oneVar1 = 'foo', oneVar2 = 'bar';
 noop(oneVar1);
 noop(oneVar2);
 
+// `one-var-declaration-per-line`.
+const oneVar1 = 'foo'; const oneVar2 = 'bar';
+
+noop(oneVar1);
+noop(oneVar2);
+
 // `operator-linebreak`.
 const operatorLineBreak = 1 +
   2;

--- a/test/index.js
+++ b/test/index.js
@@ -62,6 +62,7 @@ describe('eslint-config-seegno', () => {
       'no-underscore-dangle',
       'object-curly-spacing',
       'one-var',
+      'one-var-declaration-per-line',
       'operator-linebreak',
       'padded-blocks',
       'quote-props',


### PR DESCRIPTION
This rule, in addition to the already existing `one-var`, makes JSCS's `requireLineBreakAfterVariableAssignment` redundant. So this PR is one small step towards removing our JSCS config for good.