### PR TITLE
Add sql template plugin and `sql-template/no-unsafe-query` rule

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "eslint-plugin-babel": "^3.3.0",
     "eslint-plugin-mocha": "^4.0.0",
     "eslint-plugin-sort-class-members": "^1.0.1",
-    "eslint-plugin-sorting": "^0.3.0"
+    "eslint-plugin-sorting": "^0.3.0",
+    "eslint-plugin-sql-template": "^2.0.0"
   },
   "devDependencies": {
     "eslint": "^3.0.1",

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ module.exports = {
   },
   extends: ['eslint:recommended', 'plugin:sort-class-members/recommended'],
   parser: 'babel-eslint',
-  plugins: ['babel', 'mocha', 'sort-class-members', 'sorting'],
+  plugins: ['babel', 'mocha', 'sort-class-members', 'sorting', 'sql-template'],
   root: true,
   rules: {
     'accessor-pairs': 'error',
@@ -164,6 +164,7 @@ module.exports = {
     'space-infix-ops': 'error',
     'space-unary-ops': 'error',
     'spaced-comment': 'error',
+    'sql-template/no-unsafe-query': 'error',
     strict: 'off',
     'template-curly-spacing': 'error',
     'valid-jsdoc': 'error',

--- a/test/fixtures/correct.js
+++ b/test/fixtures/correct.js
@@ -242,6 +242,16 @@ noop(spaceUnaryOps2);
 // `spaced-comment`.
 // spaced comment.
 
+// `sql-template/no-unsafe-query`.
+const db = {
+  query: noop()
+};
+const foo = 'foo';
+const sql = 'sql-tag';
+
+db.query(sql`SELECT ${foo} FROM bar`);
+db.query(`SELECT foo FROM bar`);
+
 // `template-curly-spacing`.
 const templateCurlySpacing = 'foo';
 

--- a/test/fixtures/incorrect.js
+++ b/test/fixtures/incorrect.js
@@ -269,6 +269,14 @@ noop(spaceUnaryOps2);
 // `spaced-comment`.
 //Comment missing space.
 
+// `sql-template/no-unsafe-query`.
+const db = {
+  query: noop()
+};
+const foo = 'foo';
+
+db.query(`SELECT ${foo} FROM bar`);
+
 // `template-curly-spacing`.
 const templateCurlySpacing = 'foo';
 

--- a/test/index.js
+++ b/test/index.js
@@ -77,6 +77,7 @@ describe('eslint-config-seegno', () => {
       'space-infix-ops',
       'space-unary-ops',
       'spaced-comment',
+      'sql-template/no-unsafe-query',
       'template-curly-spacing',
       'wrap-iife',
       'yoda'


### PR DESCRIPTION
Add the `sql-template/no-unsafe-query` rule, from the new project [`eslint-plugin-sql-template`](https://github.com/uphold/eslint-plugin-sql-template), ported from [`jscs-preset-seegno`](https://github.com/seegno/jscs-preset-seegno).

Getting this rule in our eslint config finally makes it reliable enough for it to be safe for us to drop JSCS from our projects.