### PR TITLE
Update mocha@3.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "eslint": "^3.0.1",
-    "mocha": "^2.5.3",
+    "mocha": "^3.1.1",
     "should": "^9.0.2"
   },
   "engines": {


### PR DESCRIPTION
This brings gives us the latest improvements from mocha, like `.only` no longer being fuzzy searched. It also eliminates all warnings we were getting during `npm install`.