### PR TITLE
Update sort-imports rule

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "eslint-plugin-babel": "^3.3.0",
     "eslint-plugin-mocha": "^4.0.0",
     "eslint-plugin-sort-class-members": "^1.0.1",
+    "eslint-plugin-sort-imports-es6": "^0.0.3",
     "eslint-plugin-sorting": "^0.3.0",
     "eslint-plugin-sql-template": "^2.0.0"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ module.exports = {
   },
   extends: ['eslint:recommended', 'plugin:sort-class-members/recommended'],
   parser: 'babel-eslint',
-  plugins: ['babel', 'mocha', 'sort-class-members', 'sorting', 'sql-template'],
+  plugins: ['babel', 'mocha', 'sort-class-members', 'sort-imports-es6', 'sorting', 'sql-template'],
   root: true,
   rules: {
     'accessor-pairs': 'error',
@@ -152,10 +152,10 @@ module.exports = {
     'require-yield': 'error',
     semi: 'error',
     'semi-spacing': 'error',
-    'sort-imports': ['error', {
+    'sort-imports-es6/sort-imports-es6': ['error', {
       ignoreCase: false,
       ignoreMemberSort: false,
-      memberSyntaxSortOrder: ['none', 'all', 'single', 'multiple']
+      memberSyntaxSortOrder: ['none', 'all', 'multiple', 'single']
     }],
     'sorting/sort-object-props': 'error',
     'space-before-blocks': 'error',

--- a/test/fixtures/correct.js
+++ b/test/fixtures/correct.js
@@ -198,16 +198,19 @@ for (let semiSpacing = 0; semiSpacing < 10; ++semiSpacing) {
 }
 
 // `sort-imports`.
-import SortImport1 from 'sort-import1';
-import { sortImport2 } from 'sort-import2';
-import sortImport4 from 'sort-import4';
-import { sortImport3, sortImport5 } from 'sort-import';
+import 'import-1';
+import * as Import6 from 'import-2';
+import { Import5, import4 } from 'import-3';
+import { import3 } from 'import-4';
+import Import2 from 'import-5';
+import import1 from 'import-6';
 
-noop(SortImport1);
-noop(sortImport2);
-noop(sortImport3);
-noop(sortImport4);
-noop(sortImport5);
+noop(Import2);
+noop(Import5);
+noop(Import6);
+noop(import1);
+noop(import3);
+noop(import4);
 
 // `sorting/sort-object-props`.
 const sortObjectProps1 = 'foo';

--- a/test/fixtures/incorrect.js
+++ b/test/fixtures/incorrect.js
@@ -220,12 +220,11 @@ for (let semiSpacing = 0;semiSpacing < 10;++semiSpacing) {
 }
 
 // `sort-imports`.
-import { sortImport2, sortImport3 } from 'sort-import';
-import { sortImport1 } from 'sort-import1';
+import import1 from 'import-1';
+import { import2 } from 'import-2';
 
-noop(sortImport1);
-noop(sortImport2);
-noop(sortImport3);
+noop(import1);
+noop(import2);
 
 // `sorting/sort-object-props`.
 const sortObjectProps1 = 'foo';

--- a/test/index.js
+++ b/test/index.js
@@ -69,7 +69,7 @@ describe('eslint-config-seegno', () => {
       'quotes',
       'semi',
       'semi-spacing',
-      'sort-imports',
+      'sort-imports-es6/sort-imports-es6',
       'sorting/sort-object-props',
       'space-before-blocks',
       'space-before-function-paren',


### PR DESCRIPTION
This PR adds the [sort-imports-es6](https://github.com/erikdesjardins/eslint-plugin-sort-imports-es6) plugin, which overrides the [sort-imports](http://eslint.org/docs/rules/sort-imports) rule. 

The rule is now configured according to @joaogranado suggestion on #43:

```js
import 'module-1';
import * as F from 'module-2';
import { E, d } from 'module-3';
import { c } from 'module-4';
import B from 'module-5';
import a from 'module-6';
```

Closes #43