### PR TITLE
Remove eslint-plugin-babel

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,7 @@
     "version": "npm run changelog --future-release=$npm_package_version && git add -A CHANGELOG.md"
   },
   "dependencies": {
-    "babel-eslint": "^6.1.2",
-    "eslint-plugin-babel": "^3.3.0",
+    "babel-eslint": "^7.1.1",
     "eslint-plugin-mocha": "^4.0.0",
     "eslint-plugin-sort-class-members": "^1.0.1",
     "eslint-plugin-sort-imports-es6": "^0.0.3",

--- a/src/index.js
+++ b/src/index.js
@@ -11,15 +11,13 @@ module.exports = {
   },
   extends: ['eslint:recommended', 'plugin:sort-class-members/recommended'],
   parser: 'babel-eslint',
-  plugins: ['babel', 'mocha', 'sort-class-members', 'sort-imports-es6', 'sorting', 'sql-template'],
+  plugins: ['mocha', 'sort-class-members', 'sort-imports-es6', 'sorting', 'sql-template'],
   root: true,
   rules: {
     'accessor-pairs': 'error',
     'array-bracket-spacing': 'error',
-    'arrow-parens': 'off',
+    'arrow-parens': ['error', 'as-needed'],
     'arrow-spacing': 'error',
-    'babel/arrow-parens': ['error', 'as-needed'],
-    'babel/generator-star-spacing': ['error', 'before'],
     'block-scoped-var': 'error',
     'block-spacing': 'off',
     'brace-style': ['error', '1tbs', {
@@ -43,7 +41,7 @@ module.exports = {
     'func-style': ['error', 'declaration', {
       allowArrowFunctions: true
     }],
-    'generator-star-spacing': 'off',
+    'generator-star-spacing': ['error', 'before'],
     'id-length': ['error', {
       exceptions: ['_', 'e', 'i']
     }],

--- a/test/fixtures/correct.js
+++ b/test/fixtures/correct.js
@@ -6,6 +6,11 @@ function noop() {
 // `array-bracket-spacing`, `comma-spacing` and `no-multi-spaces`.
 noop(['bar', 'foo']);
 
+// `arrow-parens`
+noop(() => 'bar');
+noop(foo => foo);
+noop((foo, bar) => [foo, bar]);
+
 // `brace-style`.
 try {
   noop();

--- a/test/fixtures/correct.js
+++ b/test/fixtures/correct.js
@@ -42,6 +42,11 @@ const dotNotation = {};
 
 dotNotation.foo = 'bar';
 
+// `generator-star-spacing`
+noop(function *() {});
+noop(function *foo() {});
+noop({ *foo() {} });
+
 // `id-match`.
 let idmatch;
 let idMatch;

--- a/test/fixtures/incorrect.js
+++ b/test/fixtures/incorrect.js
@@ -6,6 +6,9 @@ function noop() {
 // `array-bracket-spacing`.
 noop([ 'bar', 'foo']);
 
+// `arrow-parens`
+noop((foo) => {});
+
 // `brace-style`.
 try {
   noop();

--- a/test/fixtures/incorrect.js
+++ b/test/fixtures/incorrect.js
@@ -45,6 +45,11 @@ const dotNotation = {};
 
 dotNotation['foo'] = 'bar';
 
+// `generator-star-spacing`
+noop(function* () {});
+noop(function* foo() {});
+noop({ * foo() {} });
+
 // `id-match`.
 let id_match;
 


### PR DESCRIPTION
This removes the `eslint-plugin-babel` as the features we are using have been absorbed by `eslint` namely  [generator-star-spacing](http://eslint.org/docs/rules/generator-star-spacing) and [arrow-parens](http://eslint.org/docs/rules/arrow-parens).

`babel-eslint` has been bumped to 7.1.1.

Refs #65