### PR TITLE
Add `capitalized-comments` rule

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -26,6 +26,9 @@ module.exports = {
       allowSingleLine: true
     }],
     camelcase: 'off',
+    'capitalized-comments': ['error', 'always', {
+      ignoreConsecutiveComments: true
+    }],
     'comma-dangle': 'error',
     'comma-spacing': 'error',
     'comma-style': 'error',

--- a/test/fixtures/correct.js
+++ b/test/fixtures/correct.js
@@ -40,7 +40,7 @@ xtest();
 
 // Avoid extra `no-unused-vars` violations.
 function noop() {
-  // do nothing
+  // Do nothing
 }
 
 // `array-bracket-spacing`, `comma-spacing` and `no-multi-spaces`.
@@ -59,6 +59,13 @@ try {
 }
 
 noop(function *() { return yield noop(); });
+
+// `capitalized-comments`.
+
+noop();
+
+// First line must be capitalized.
+// following lines don't.
 
 // `comma-dangle`, `comma-style`.
 noop({ bar: 'foo', foo: 'bar' });
@@ -317,7 +324,7 @@ const spaceUnaryOps2 = ++spaceUnaryOps1;
 noop(spaceUnaryOps2);
 
 // `spaced-comment`.
-// spaced comment.
+// Spaced comment.
 
 // `sql-template/no-unsafe-query`.
 const db = {

--- a/test/fixtures/incorrect.js
+++ b/test/fixtures/incorrect.js
@@ -1,6 +1,6 @@
 // Avoid extra `no-unused-vars` violations.
 function noop() {
-  // do nothing
+  // Do nothing
 }
 
 // `array-bracket-spacing`.
@@ -16,6 +16,13 @@ try {
 catch (e) {
   noop();
 }
+
+// `capitalized-comments`.
+
+noop();
+
+// first line must be capitalized.
+// following lines don't.
 
 // `comma-dangle`.
 noop({ bar: 'foo', foo: 'bar', });

--- a/test/index.js
+++ b/test/index.js
@@ -36,6 +36,7 @@ describe('eslint-config-seegno', () => {
       'array-bracket-spacing',
       'arrow-parens',
       'brace-style',
+      'capitalized-comments',
       'comma-dangle',
       'comma-spacing',
       'comma-style',


### PR DESCRIPTION
Add [`capitalized-comments`](http://eslint.org/docs/rules/capitalized-comments) to require comments to be capitalized. This only applies to the first line of the comment (see `test/fixtures/` for examples of valid/invalid code).

This requires the latest minor version of eslint available as of this PR's creation moment (3.11).