### PR TITLE
Enforce the newline-before-return rule

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -63,6 +63,7 @@ module.exports = {
     'new-cap': 'error',
     'new-parens': 'error',
     'newline-after-var': 'error',
+    'newline-before-return': 'error',
     'no-alert': 'error',
     'no-array-constructor': 'error',
     'no-bitwise': 'error',

--- a/test/fixtures/correct.js
+++ b/test/fixtures/correct.js
@@ -85,6 +85,17 @@ const newLineAfterVar = 'foo';
 
 noop(newLineAfterVar);
 
+// `newline-before-return`.
+function funcThatReturns(bar) {
+  if (!bar) {
+    return;
+  }
+
+  return bar;
+}
+
+funcThatReturns('foo');
+
 // `no-class-assign`.
 class NoClassAssign { }
 

--- a/test/fixtures/incorrect.js
+++ b/test/fixtures/incorrect.js
@@ -78,6 +78,16 @@ const newCap = new cap();
 const newLineAfterVar = 'foo';
 noop(newLineAfterVar);
 
+// `newline-before-return`.
+function funcThatReturns(bar) {
+  if (!bar) {
+    return;
+  }
+  return bar;
+}
+
+funcThatReturns('foo');
+
 // `no-class-assign`.
 class NoClassAssign { }
 

--- a/test/index.js
+++ b/test/index.js
@@ -48,6 +48,7 @@ describe('eslint-config-seegno', () => {
       'mocha/no-exclusive-tests',
       'new-cap',
       'newline-after-var',
+      'newline-before-return',
       'no-class-assign',
       'no-const-assign',
       'no-constant-condition',


### PR DESCRIPTION
May this be an interesting rule for the linter to enforce? It is one that we are enforcing on code reviews.