### PR TITLE
Replace sorting plugin with sort keys

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "eslint-plugin-sql-template": "^2.0.0"
   },
   "devDependencies": {
-    "eslint": "^3.0.1",
+    "eslint": "^3.16.1",
     "mocha": "^3.1.1",
     "should": "^9.0.2"
   },

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "eslint-plugin-mocha": "^4.0.0",
     "eslint-plugin-sort-class-members": "^1.0.1",
     "eslint-plugin-sort-imports-es6": "^0.0.3",
-    "eslint-plugin-sorting": "^0.3.0",
     "eslint-plugin-sql-template": "^2.0.0"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -9,9 +9,9 @@ module.exports = {
     mocha: true,
     node: true
   },
-  extends: ['eslint:recommended', 'plugin:sort-class-members/recommended'],
+  extends: ['eslint:recommended'],
   parser: 'babel-eslint',
-  plugins: ['mocha', 'sort-class-members', 'sort-imports-es6', 'sorting', 'sql-template'],
+  plugins: ['mocha', 'sort-class-members', 'sort-imports-es6', 'sql-template'],
   root: true,
   rules: {
     'accessor-pairs': 'error',
@@ -156,7 +156,9 @@ module.exports = {
       ignoreMemberSort: false,
       memberSyntaxSortOrder: ['none', 'all', 'multiple', 'single']
     }],
-    'sorting/sort-object-props': 'error',
+    'sort-keys': ['error', 'asc', {
+      natural: true
+    }],
     'space-before-blocks': 'error',
     'space-before-function-paren': ['error', 'never'],
     'space-in-parens': 'error',

--- a/test/fixtures/correct.js
+++ b/test/fixtures/correct.js
@@ -233,13 +233,11 @@ noop(import1);
 noop(import3);
 noop(import4);
 
-// `sorting/sort-object-props`.
-const sortObjectProps1 = 'foo';
-const sortObjectProps2 = 'bar';
-
+// `sort-keys`.
 const sortObjectProps = {
-  [`${sortObjectProps1}`]: 'foo',
-  [`${sortObjectProps2}`]: 'bar'
+  var1: 'foo',
+  var9: 'bar',
+  var10: 'biz'
 };
 
 noop(sortObjectProps);

--- a/test/fixtures/incorrect.js
+++ b/test/fixtures/incorrect.js
@@ -244,13 +244,11 @@ import { import2 } from 'import-2';
 noop(import1);
 noop(import2);
 
-// `sorting/sort-object-props`.
-const sortObjectProps1 = 'foo';
-const sortObjectProps2 = 'bar';
-
+// `sort-keys`.
 const sortObjectProps = {
-  [`${sortObjectProps2}`]: 'bar',
-  [`${sortObjectProps1}`]: 'foo'
+  var1: 'foo',
+  var10: 'bar',
+  var9: 'biz'
 };
 
 noop(sortObjectProps);

--- a/test/index.js
+++ b/test/index.js
@@ -71,7 +71,7 @@ describe('eslint-config-seegno', () => {
       'semi',
       'semi-spacing',
       'sort-imports-es6/sort-imports-es6',
-      'sorting/sort-object-props',
+      'sort-keys',
       'space-before-blocks',
       'space-before-function-paren',
       'space-in-parens',


### PR DESCRIPTION
This PR replaces the `sorting-plugin` with the `sort-keys` rule which is available since _eslint 3.3.0_.

The motivation for this change is to respect the team's _natural_ sort order requirement. Also, it's one less dependency (yay!).

Example that did not trigger an error with `sorting-plugin` (and was not configurable):

```js
{
  var1: 'foo',
  var10: 'foo',
  var2: 'foo',
  var9: 'bar'
};
```

Using the new `sort-keys` rule, the object would have to be written as:

```js
{
  var1: 'foo',
  var2: 'foo',
  var9: 'bar',
  var10: 'foo'
};
```

😌 