### PR TITLE
Add jasmine and jest environments

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,8 @@
 module.exports = {
   env: {
     es6: true,
+    jasmine: true,
+    jest: true,
     mocha: true,
     node: true
   },

--- a/test/fixtures/correct.js
+++ b/test/fixtures/correct.js
@@ -1,3 +1,43 @@
+// `jasmine`, `jest` and `mocha` envs.
+after();
+afterAll();
+afterEach();
+before();
+beforeAll();
+beforeEach();
+check();
+context();
+describe();
+expect();
+fail();
+fdescribe();
+fit();
+gen();
+it();
+jasmine();
+jest();
+mocha();
+pending();
+pit();
+require();
+run();
+runs();
+setup();
+specify();
+spyOn();
+suite();
+suiteSetup();
+suiteTeardown();
+teardown();
+test();
+waits();
+waitsFor();
+xcontext();
+xdescribe();
+xit();
+xspecify();
+xtest();
+
 // Avoid extra `no-unused-vars` violations.
 function noop() {
   // do nothing

--- a/test/fixtures/incorrect.js
+++ b/test/fixtures/incorrect.js
@@ -170,6 +170,9 @@ class Child extends NoThisBeforeSuper {
 
 noop(Child);
 
+// `no-undef`.
+bar();
+
 // `no-underscore-dangle`.
 class NoUnderscoreDangle {
 

--- a/test/index.js
+++ b/test/index.js
@@ -63,6 +63,7 @@ describe('eslint-config-seegno', () => {
       'no-multiple-empty-lines',
       'no-spaced-func',
       'no-this-before-super',
+      'no-undef',
       'no-underscore-dangle',
       'no-unused-vars',
       'object-curly-spacing',


### PR DESCRIPTION
This PR adds `jasmine` and `jest` environments, allowing its globals when using Jest as test framework.

Closes #71 