### PR TITLE
Disable no-confusing-arrow rule

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -70,7 +70,6 @@ module.exports = {
     'no-caller': 'error',
     'no-catch-shadow': 'off',
     'no-cond-assign': ['error', 'always'],
-    'no-confusing-arrow': 'error',
     'no-div-regex': 'error',
     'no-duplicate-imports': 'error',
     'no-else-return': 'error',

--- a/test/fixtures/correct.js
+++ b/test/fixtures/correct.js
@@ -101,6 +101,9 @@ class NoClassAssign { }
 
 noop(NoClassAssign);
 
+// `no-confusing-arrow`.
+((foo, bar) => foo ? bar : foo)();
+
 // `no-const-assign`.
 let noConstAssign = true;
 


### PR DESCRIPTION
This PR disables the [no-confusing-arrow](http://eslint.org/docs/rules/no-confusing-arrow) rule as it reduces the ability of the arrow functions return value shorthand. 

The arrow function syntax is different than any comparison operator, so I believe it shouldn't be considered confusing in the first place.