### PR TITLE
Enable `require-await` rule

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -148,6 +148,7 @@ module.exports = {
       allowTemplateLiterals: true
     }],
     radix: 'error',
+    'require-await': 'error',
     'require-yield': 'error',
     semi: 'error',
     'semi-spacing': 'error',

--- a/test/fixtures/correct.js
+++ b/test/fixtures/correct.js
@@ -210,6 +210,11 @@ const quotes2 = `foo`;
 noop(quotes1);
 noop(quotes2);
 
+// `require-await`.
+(async () => {
+  await noop();
+})();
+
 // `semi`.
 noop();
 

--- a/test/fixtures/incorrect.js
+++ b/test/fixtures/incorrect.js
@@ -226,6 +226,9 @@ const quotes = "foo";
 
 noop(quotes);
 
+// `require-await`.
+(async () => {})();
+
 // `semi`.
 noop()
 


### PR DESCRIPTION
This PR enables the [require-await](http://eslint.org/docs/rules/require-await) rule, preventing `async` functions to have an `await` expression.