### PR TITLE
Update eslint to version v4.7.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "eslint-plugin-sql-template": "^2.0.0"
   },
   "devDependencies": {
-    "eslint": "^3.16.1",
+    "eslint": "^4.7.2",
     "mocha": "^3.1.1",
     "should": "^9.0.2"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -161,7 +161,7 @@ module.exports = {
       natural: true
     }],
     'space-before-blocks': 'error',
-    'space-before-function-paren': ['error', 'never'],
+    'space-before-function-paren': ['error', { anonymous: 'never', named: 'never' }],
     'space-in-parens': 'error',
     'space-infix-ops': 'error',
     'space-unary-ops': 'error',

--- a/src/index.js
+++ b/src/index.js
@@ -138,7 +138,7 @@ module.exports = {
     'one-var-declaration-per-line': ['error', 'always'],
     'operator-assignment': 'error',
     'operator-linebreak': ['error', 'none'],
-    'padded-blocks': ['error', 'never'],
+    'padded-blocks': ['error', { classes: 'always', blocks: 'never', switches: 'never' }],
     'prefer-arrow-callback': 'error',
     'prefer-const': 'error',
     'prefer-spread': 'error',

--- a/test/fixtures/correct.js
+++ b/test/fixtures/correct.js
@@ -117,6 +117,7 @@ if (noConstantCondition) {
 
 // `no-dupe-class-members`.
 class NoDupeClassMembers {
+
   bar() {
     return 'bar';
   }
@@ -124,6 +125,7 @@ class NoDupeClassMembers {
   foo() {
     return 'foo';
   }
+
 }
 
 noop(NoDupeClassMembers);
@@ -153,10 +155,12 @@ noop();
 const NoThisBeforeSuper = require('no-this-before-super');
 
 class Child extends NoThisBeforeSuper {
+
   constructor() {
     super();
     this.foo = 'bar';
   }
+
 }
 
 noop(Child);
@@ -186,11 +190,17 @@ const operatorLineBreak = 1 + 2;
 noop(operatorLineBreak);
 
 // `padded-blocks`.
-const paddedBlocks = true;
+class PaddleBlocks {
 
-if (paddedBlocks) {
-  noop();
+  constructor() {
+    switch (true) {
+      default: noop();
+    }
+  }
+
 }
+
+noop(new PaddleBlocks());
 
 // `quote-props`.
 const quoteProps = {

--- a/test/fixtures/incorrect.js
+++ b/test/fixtures/incorrect.js
@@ -115,6 +115,7 @@ if (true) {
 
 // `no-dupe-class-members`.
 class NoDupeClassMembers {
+
   foo() {
     return 'bar';
   }
@@ -122,6 +123,7 @@ class NoDupeClassMembers {
   foo() {
     return 'foo';
   }
+
 }
 
 noop(NoDupeClassMembers);
@@ -158,19 +160,23 @@ noop ();
 const NoThisBeforeSuper = require('no-this-before-super');
 
 class Child extends NoThisBeforeSuper {
+
   constructor() {
     this.foo = 'bar';
     super();
   }
+
 }
 
 noop(Child);
 
 // `no-underscore-dangle`.
 class NoUnderscoreDangle {
+
   constructor() {
     this._foo();
   }
+
 }
 
 noop(new NoUnderscoreDangle());
@@ -202,12 +208,16 @@ const operatorLineBreak = 1 +
 noop(operatorLineBreak);
 
 // `padded-blocks`.
-const paddedBlocks = true;
+class PaddleBlocks {
+  constructor() {
 
-if (paddedBlocks) {
+    switch (true) {
 
-  noop();
+      default: noop();
 
+    }
+
+  }
 }
 
 // `quote-props`.


### PR DESCRIPTION
This PR updates eslint to version `v4.7.2`.

It also updates `padded-blocks` and `space-before-function-paren` rules.