### PR TITLE
Fix typo in environment.js

### DIFF
--- a/test/fixtures/environment.js
+++ b/test/fixtures/environment.js
@@ -1,4 +1,4 @@
-// Incorrect environment-specific (os or editor) setings.
+// Incorrect environment-specific (os or editor) settings.
 
 // `linebreak-style` - Windows line endings (CRLF).
 


### PR DESCRIPTION
This PR fixes a small typo in the `environment.js`.