### PR TITLE
Update babel-eslint@8.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "version": "npm run changelog --future-release=$npm_package_version && git add -A CHANGELOG.md"
   },
   "dependencies": {
-    "babel-eslint": "^7.1.1",
+    "babel-eslint": "^8.0.1",
     "eslint-plugin-jest": "^21.2.0",
     "eslint-plugin-mocha": "^4.0.0",
     "eslint-plugin-sort-class-members": "^1.0.1",


### PR DESCRIPTION
This PR updates babel-eslint to version `v8.0.1`.