### PR TITLE
Add switch-case plugin and rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "eslint-plugin-mocha": "^4.0.0",
     "eslint-plugin-sort-class-members": "^1.0.1",
     "eslint-plugin-sort-imports-es6": "^0.0.3",
-    "eslint-plugin-sql-template": "^2.0.0"
+    "eslint-plugin-sql-template": "^2.0.0",
+    "eslint-plugin-switch-case": "^1.1.2"
   },
   "devDependencies": {
     "eslint": "^4.7.2",

--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ module.exports = {
   },
   extends: ['eslint:recommended'],
   parser: 'babel-eslint',
-  plugins: ['jest', 'mocha', 'sort-class-members', 'sort-imports-es6', 'sql-template'],
+  plugins: ['jest', 'mocha', 'sort-class-members', 'sort-imports-es6', 'sql-template', 'switch-case'],
   root: true,
   rules: {
     'accessor-pairs': 'error',
@@ -176,6 +176,7 @@ module.exports = {
     'spaced-comment': 'error',
     'sql-template/no-unsafe-query': 'error',
     strict: 'off',
+    'switch-case/newline-between-switch-case': ['error', 'always'],
     'template-curly-spacing': 'error',
     'valid-jsdoc': 'error',
     'vars-on-top': 'error',

--- a/test/fixtures/correct.js
+++ b/test/fixtures/correct.js
@@ -342,6 +342,15 @@ const sql = 'sql-tag';
 db.query(sql`SELECT ${foo} FROM bar`);
 db.query(`SELECT foo FROM bar`);
 
+// `switch-case/newline-between-switch-case`.
+switch (true) {
+  case 'foobar':
+    break;
+
+  default:
+    return;
+}
+
 // `template-curly-spacing`.
 const templateCurlySpacing = 'foo';
 

--- a/test/fixtures/incorrect.js
+++ b/test/fixtures/incorrect.js
@@ -337,6 +337,14 @@ const foo = 'foo';
 
 db.query(`SELECT ${foo} FROM bar`);
 
+// `switch-case/newline-between-switch-case`.
+switch (true) {
+  case 'foobar':
+    break;
+  default:
+    return;
+}
+
 // `template-curly-spacing`.
 const templateCurlySpacing = 'foo';
 

--- a/test/index.js
+++ b/test/index.js
@@ -121,6 +121,7 @@ describe('eslint-config-seegno', () => {
       'space-unary-ops',
       'spaced-comment',
       'sql-template/no-unsafe-query',
+      'switch-case/newline-between-switch-case',
       'template-curly-spacing',
       'template-curly-spacing',
       'wrap-iife',


### PR DESCRIPTION
This PR adds [eslint-plugin-switch-case](https://www.npmjs.com/package/eslint-plugin-switch-case) and the following rule:

- `newline-between-switch-case`.