### PR TITLE
Add new-with-error plugin and rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "babel-eslint": "^8.0.1",
     "eslint-plugin-jest": "^21.2.0",
     "eslint-plugin-mocha": "^4.0.0",
+    "eslint-plugin-new-with-error": "^1.1.0",
     "eslint-plugin-sort-class-members": "^1.0.1",
     "eslint-plugin-sort-imports-es6": "^0.0.3",
     "eslint-plugin-sql-template": "^2.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ module.exports = {
   },
   extends: ['eslint:recommended'],
   parser: 'babel-eslint',
-  plugins: ['jest', 'mocha', 'sort-class-members', 'sort-imports-es6', 'sql-template', 'switch-case'],
+  plugins: ['jest', 'mocha', 'new-with-error', 'sort-class-members', 'sort-imports-es6', 'sql-template', 'switch-case'],
   root: true,
   rules: {
     'accessor-pairs': 'error',
@@ -70,6 +70,7 @@ module.exports = {
     'mocha/no-exclusive-tests': 'error',
     'new-cap': 'error',
     'new-parens': 'error',
+    'new-with-error/new-with-error': 'error',
     'newline-after-var': 'error',
     'newline-before-return': 'error',
     'no-alert': 'error',

--- a/test/fixtures/correct.js
+++ b/test/fixtures/correct.js
@@ -223,6 +223,13 @@ noop(Child);
 // TODO: do something.
 // FIXME: this is not a good idea.
 
+// `new-with-error`.
+try {
+  noop();
+} catch (e) {
+  throw new Error();
+}
+
 // `object-curly-spacing`.
 const objectCurlySpacing1 = { foo: 'bar' };
 const objectCurlySpacing2 = {};

--- a/test/fixtures/incorrect.js
+++ b/test/fixtures/incorrect.js
@@ -110,6 +110,13 @@ const cap = require('cap');
 
 new cap();
 
+// `new-with-error`.
+try {
+  noop();
+} catch (e) {
+  throw Error();
+}
+
 // `newline-after-var`.
 const newLineAfterVar = 'foo';
 noop(newLineAfterVar);

--- a/test/index.js
+++ b/test/index.js
@@ -75,6 +75,7 @@ describe('eslint-config-seegno', () => {
       'keyword-spacing',
       'no-new',
       'new-cap',
+      'new-with-error/new-with-error',
       'newline-after-var',
       'newline-before-return',
       'no-class-assign',


### PR DESCRIPTION
This PR adds the [eslint-plugin-new-with-error](https://github.com/Trott/eslint-plugin-new-with-error) and the respective rule.

This will enforce the user to throw `Error` objects using `new`.   

This is only stylistic and to improve code base standards has there's no difference between creating Error objects with function call or `new`:
https://www.ecma-international.org/ecma-262/8.0/index.html#sec-error-objects