### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,17 +26,17 @@
     "version": "npm run changelog --future-release=$npm_package_version && git add -A CHANGELOG.md"
   },
   "dependencies": {
-    "babel-eslint": "^8.0.1",
-    "eslint-plugin-jest": "^21.2.0",
-    "eslint-plugin-mocha": "^4.0.0",
+    "babel-eslint": "^8.2.2",
+    "eslint-plugin-jest": "^21.12.0",
+    "eslint-plugin-mocha": "^4.11.0",
     "eslint-plugin-new-with-error": "^1.1.0",
-    "eslint-plugin-sort-class-members": "^1.0.1",
+    "eslint-plugin-sort-class-members": "^1.3.0",
     "eslint-plugin-sort-imports-es6": "^0.0.3",
     "eslint-plugin-sql-template": "^2.0.0",
     "eslint-plugin-switch-case": "^1.1.2"
   },
   "devDependencies": {
-    "eslint": "^4.8.0",
+    "eslint": "^4.18.0",
     "mocha": "^3.1.1",
     "should": "^9.0.2"
   },


### PR DESCRIPTION
This PR updates the following dependencies:
- babel-eslint@8.2.2
- eslint-plugin-jest@21.12.0
- eslint-plugin-mocha@4.11.0
- eslint-plugin-sort-class-members@1.3.0
- eslint@4.18.0