### PR TITLE
Fix sort destructure keys rule

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "eslint-plugin-new-with-error": "^1.1.0",
     "eslint-plugin-react": "^7.11.1",
     "eslint-plugin-sort-class-members": "^1.3.0",
-    "eslint-plugin-sort-destructure-keys": "^1.0.0",
+    "eslint-plugin-sort-destructure-keys": "^1.1.0",
     "eslint-plugin-sort-imports-es6": "^0.0.3",
     "eslint-plugin-sql-template": "^2.0.0",
     "eslint-plugin-switch-case": "^1.1.2"

--- a/src/index.js
+++ b/src/index.js
@@ -202,7 +202,9 @@ module.exports = {
     'require-yield': 'error',
     semi: 'error',
     'semi-spacing': 'error',
-    'sort-destructure-keys/sort-destructure-keys': 2,
+    'sort-destructure-keys/sort-destructure-keys': ['error', {
+      caseSensitive: true
+    }],
     'sort-imports-es6/sort-imports-es6': ['error', {
       ignoreCase: false,
       ignoreMemberSort: false,


### PR DESCRIPTION
This PR updates the `eslint-plugin-sort-destructure-keys` dependency to add the `caseSensitive` option to the `sort-destructure-keys` rule, to make it consistent with other sorting rules.