### PR TITLE
Fix newline-between-switch-case fallthrough

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -262,7 +262,7 @@ module.exports = {
     'spaced-comment': 'error',
     'sql-template/no-unsafe-query': 'error',
     strict: 'off',
-    'switch-case/newline-between-switch-case': ['error', 'always'],
+    'switch-case/newline-between-switch-case': ['error', 'always', { fallthrough: 'never' }],
     'template-curly-spacing': 'error',
     'valid-jsdoc': 'error',
     'vars-on-top': 'error',

--- a/test/fixtures/correct.js
+++ b/test/fixtures/correct.js
@@ -352,6 +352,7 @@ db.query(`SELECT foo FROM bar`);
 // `switch-case/newline-between-switch-case`.
 switch (true) {
   case 'foobar':
+  case 'foobiz':
     break;
 
   default:

--- a/test/fixtures/incorrect.js
+++ b/test/fixtures/incorrect.js
@@ -344,9 +344,11 @@ const foo = 'foo';
 
 db.query(`SELECT ${foo} FROM bar`);
 
-// `switch-case/newline-between-switch-case`.
+// `switch-case/newline-between-switch-case` and `no-fallthrough`.
 switch (true) {
   case 'foobar':
+
+  case 'foobiz':
     break;
   default:
     return;

--- a/test/index.js
+++ b/test/index.js
@@ -123,6 +123,8 @@ describe('eslint-config-seegno', () => {
       'spaced-comment',
       'sql-template/no-unsafe-query',
       'switch-case/newline-between-switch-case',
+      'no-fallthrough',
+      'switch-case/newline-between-switch-case',
       'template-curly-spacing',
       'template-curly-spacing',
       'wrap-iife',


### PR DESCRIPTION
This PR fixes the __empty case clauses__ from needing an _empty line_ between them.
This bug was introduced in #83.

__The following example, although correct, throws an error:__
```js
switch ('foo') {
    case 'foo': // Fix: Newline required between switch cases.
    case 'bar':
      return 'biz';

    default:
      return null;
  }
```