### PR TITLE
Add React version to settings

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -285,6 +285,9 @@ module.exports = {
   settings: {
     flowtype: {
       onlyFilesWithFlowAnnotation: true
+    },
+    react: {
+      version: 'detect'
     }
   }
 };


### PR DESCRIPTION
This PR updates the settings with the React version set to `detect`, which picks the version the application has installed.

This was necessary because eslint keeps complaining with this warning:

`Warning: React version not specified in eslint-plugin-react settings.`

Documentation: https://github.com/yannickcr/eslint-plugin-react#configuration