### PR TITLE
Add react jsx-tag-spacing rule

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -199,6 +199,12 @@ module.exports = {
     'react/jsx-no-literals': 'error',
     'react/jsx-no-undef': 'error',
     'react/jsx-sort-props': 'error',
+    'react/jsx-tag-spacing': ['error', {
+      'afterOpening': 'never',
+      'beforeClosing': 'never',
+      'beforeSelfClosing': 'always',
+      'closingSlash': 'never'
+    }],
     'react/jsx-uses-react': 'error',
     'react/jsx-uses-vars': 'error',
     'react/jsx-wrap-multilines': 'error',

--- a/test/fixtures/correct.js
+++ b/test/fixtures/correct.js
@@ -389,10 +389,19 @@ if (yoda === true) {
 // `react-hooks/rules-of-hooks`.
 const useEffect = noop;
 
-const ReactComponent = () => {
+const RulesOfHooks = () => {
   useEffect(noop);
 
   return null;
 };
 
-noop(ReactComponent);
+noop(RulesOfHooks);
+
+// `react/jsx-tag-spacing`.
+const React = null;
+
+const TagSpacing = () => (
+  <div />
+);
+
+noop(TagSpacing);

--- a/test/fixtures/incorrect.js
+++ b/test/fixtures/incorrect.js
@@ -384,7 +384,7 @@ if (true === yoda) {
 // `react-hooks/rules-of-hooks`.
 const useEffect = noop;
 
-const ReactComponent = () => {
+const RulesOfHooks = () => {
   if (Math.random() > 0.5) {
     useEffect(noop);
   }
@@ -392,4 +392,33 @@ const ReactComponent = () => {
   return null;
 };
 
-noop(ReactComponent);
+noop(RulesOfHooks);
+
+// `react/jsx-tag-spacing`.
+const React = null;
+
+const TagSpacingAfterOpening = () => (
+  < div />
+);
+
+noop(TagSpacingAfterOpening);
+
+const TagSpacingBeforeClosing = () => (
+  <div>
+    {'foo'}
+  </div >
+);
+
+noop(TagSpacingBeforeClosing);
+
+const TagSpacingBeforeSelfClosing = () => (
+  <div/>
+);
+
+noop(TagSpacingBeforeSelfClosing);
+
+const TagSpacingClosingSlash = () => (
+  <div/ >
+);
+
+noop(TagSpacingClosingSlash);

--- a/test/index.js
+++ b/test/index.js
@@ -123,14 +123,19 @@ describe('eslint-config-seegno', () => {
       'spaced-comment',
       'sql-template/no-unsafe-query',
       'switch-case/newline-between-switch-case',
-      'switch-case/newline-between-switch-case',
       'no-fallthrough',
+      'switch-case/newline-between-switch-case',
       'template-curly-spacing',
       'template-curly-spacing',
       'wrap-iife',
       'sort-destructure-keys/sort-destructure-keys',
       'yoda',
-      'react-hooks/rules-of-hooks'
+      'react-hooks/rules-of-hooks',
+      'react/jsx-tag-spacing',
+      'react/jsx-tag-spacing',
+      'react/jsx-tag-spacing',
+      'react/jsx-tag-spacing',
+      'react/jsx-tag-spacing'
     ]);
   });
 });


### PR DESCRIPTION
This PR adds `react/jsx-tag-spacing` rule from [eslint-plugin-react
](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-tag-spacing.md)

The following patterns are not considered problems:
```jsx
<FooBar />
<FooBar></FooBar>
````

The following patterns are considered problems:
```jsx
<FooBar/>
<FooBar/ >
<FooBar>< /FooBar>
<FooBar></FooBar>
```