### PR TITLE
Add react prefer-stateless-function rule

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -213,6 +213,7 @@ module.exports = {
     'react/no-string-refs': 'error',
     'react/no-unknown-property': 'error',
     'react/prefer-es6-class': 'error',
+    'react/prefer-stateless-function': 'error',
     'react/react-in-jsx-scope': 'error',
     'react/self-closing-comp': 'error',
     'react/sort-comp': ['error', {

--- a/test/fixtures/correct.js
+++ b/test/fixtures/correct.js
@@ -405,3 +405,18 @@ const TagSpacing = () => (
 );
 
 noop(TagSpacing);
+
+// `react/prefer-stateless-function`.
+class PreferStatelessFunction extends React.Component {
+
+  getFoo = () => {
+    return 'foo';
+  }
+
+  render() {
+    return this.getFoo();
+  }
+
+}
+
+noop(PreferStatelessFunction);

--- a/test/fixtures/incorrect.js
+++ b/test/fixtures/incorrect.js
@@ -422,3 +422,14 @@ const TagSpacingClosingSlash = () => (
 );
 
 noop(TagSpacingClosingSlash);
+
+// `react/prefer-stateless-function`.
+class PreferStatelessFunction extends React.Component {
+
+  render() {
+    return null;
+  }
+
+}
+
+noop(PreferStatelessFunction);

--- a/test/index.js
+++ b/test/index.js
@@ -135,7 +135,8 @@ describe('eslint-config-seegno', () => {
       'react/jsx-tag-spacing',
       'react/jsx-tag-spacing',
       'react/jsx-tag-spacing',
-      'react/jsx-tag-spacing'
+      'react/jsx-tag-spacing',
+      'react/prefer-stateless-function'
     ]);
   });
 });


### PR DESCRIPTION
This PR adds `react/prefer-stateless-function` rule from [eslint-plugin-react
](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/prefer-stateless-function.md)

The following pattern is not considered problem:
```jsx
class FooBar extends React.Component {

  getFoo = () => {
    return 'foo';
  }

  render() {
    return this.getFoo();
  }

}
````

The following pattern is considered problem:
```jsx
class FooBar extends React.Component {

  render() {
    return null;
  }

}
```