### PR TITLE
Fix minimum Node version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 
 node_js:
-  - 8
   - 10
 
 sudo: false

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "eslint": "5 || 6"
   },
   "engines": {
-    "node": ">=8"
+    "node": ">=10"
   },
   "options": {
     "mocha": "-t 10000 --require should test"


### PR DESCRIPTION
This PR changes the minimum Node version to 10, which is now required since #125 